### PR TITLE
Add support for tracking 24h volumes

### DIFF
--- a/model.go
+++ b/model.go
@@ -12,30 +12,32 @@ const schema = "filquotes"
 // Quote stores FIL price information.
 type Quote struct {
 	//lint:ignore U1000 hit for go-pg
-	tableName struct{} `pg:"filquotes.fil_quotes"`
-	Height    int64    `pg:",pk,notnull"`
-	Price     int64    `pg:",notnull"`
-	Exchange  string   `pg:",pk,notnull"`
-	Currency  string   `pg:",pk,notnull"`
+	tableName     struct{} `pg:"filquotes.fil_quotes"`
+	Height        int64    `pg:",pk,notnull"`
+	Price         int64    `pg:",notnull"`
+	VolumeBase24h int64    `pg:",notnull"`
+	Exchange      string   `pg:",pk,notnull"`
+	Currency      string   `pg:",pk,notnull"`
 }
 
 // NewQuote creates a new FIL quote for the database.
 func NewQuote(h int64, ex string, q quotetracker.Quote) Quote {
 	return Quote{
-		Height:   h,
-		Price:    toMicroFIL(q.Amount),
-		Exchange: ex,
-		Currency: q.Pair.Buy.Symbol(),
+		Height:        h,
+		Price:         toMicro(q.Amount),
+		VolumeBase24h: toMicro(q.VolumeBase24h),
+		Exchange:      ex,
+		Currency:      q.Pair.Buy.Symbol(),
 	}
 }
 
-// toMicroFIL converts FIL price to int for storage.
-func toMicroFIL(price float64) int64 {
-	return int64(price * 1000000) // microFIL
+// toMicro converts a float unit to int micro-units for storage.
+func toMicro(amount float64) int64 {
+	return int64(amount * 1000000) // micro
 }
 
-// func fromMicroFIL(price int64) float64 {
-// 	return float64(price / 1000000) // microFIL
+// func fromMicro(amount int64) float64 {
+// 	return float64(amount / 1000000) // micro
 // }
 
 // Persist uses a transaction to insert a quote in the DB.

--- a/quotetracker/coinbasepro.go
+++ b/quotetracker/coinbasepro.go
@@ -2,6 +2,7 @@ package quotetracker
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"time"
 )
@@ -11,24 +12,29 @@ const coinbaseproURL = "https://api.pro.coinbase.com"
 type coinbaseproResponse struct {
 	pair Pair
 
-	Last   string `json:"last"`
-	Volume string `json:"volume"`
+	Message string `json:"message"`
+	Last    string `json:"last"`
+	Volume  string `json:"volume"`
 }
 
 func (cbpr *coinbaseproResponse) Quote() (Quote, error) {
+	if cbpr.Message != "" {
+		return Quote{}, fmt.Errorf("coinbasepro: bad request %s: %s", cbpr.pair, cbpr.Message)
+	}
+
 	last, err := strconv.ParseFloat(cbpr.Last, 64)
 	if err != nil {
-		return Quote{}, err
+		return Quote{}, fmt.Errorf("coinbasepro: error parsing price %s: %w", cbpr.pair, err)
 	}
 	vol, err := strconv.ParseFloat(cbpr.Volume, 64)
 	if err != nil {
-		return Quote{}, err
+		return Quote{}, fmt.Errorf("coinbasepro: error parsing volume %s: %w", cbpr.pair, err)
 	}
 
 	quote := Quote{
-		Pair:      cbpr.pair,
-		Timestamp: time.Now(),
-		Amount:    last,
+		Pair:          cbpr.pair,
+		Timestamp:     time.Now(),
+		Amount:        last,
 		VolumeBase24h: vol,
 	}
 

--- a/quotetracker/coinbasepro.go
+++ b/quotetracker/coinbasepro.go
@@ -16,7 +16,11 @@ type coinbaseproResponse struct {
 }
 
 func (cbpr *coinbaseproResponse) Quote() (Quote, error) {
-	v, err := strconv.ParseFloat(cbpr.Last, 64)
+	last, err := strconv.ParseFloat(cbpr.Last, 64)
+	if err != nil {
+		return Quote{}, err
+	}
+	vol, err := strconv.ParseFloat(cbpr.Volume, 64)
 	if err != nil {
 		return Quote{}, err
 	}
@@ -24,7 +28,8 @@ func (cbpr *coinbaseproResponse) Quote() (Quote, error) {
 	quote := Quote{
 		Pair:      cbpr.pair,
 		Timestamp: time.Now(),
-		Amount:    v,
+		Amount:    last,
+		VolumeBase24h: vol,
 	}
 
 	return quote, nil

--- a/quotetracker/coinbasepro_test.go
+++ b/quotetracker/coinbasepro_test.go
@@ -49,4 +49,8 @@ func TestCoinbaseproPrice(t *testing.T) {
 	if q.Amount != 22.3019 {
 		t.Error("price amount not parsed correctly")
 	}
+
+	if q.VolumeBase24h != 214729.266 {
+		t.Error("volume amount not parsed correctly")
+	}
 }

--- a/quotetracker/coinlistpro.go
+++ b/quotetracker/coinlistpro.go
@@ -2,6 +2,7 @@ package quotetracker
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"time"
 )
@@ -11,7 +12,8 @@ const coinlistproURL = "https://trade-api.coinlist.co"
 type coinlistproResponse struct {
 	pair Pair
 
-	LastTrade coinlistproLastTrade `json:"last_trade"`
+	LastTrade     coinlistproLastTrade `json:"last_trade"`
+	VolumeBase24h string               `json:"volume_base_24h"`
 }
 
 type coinlistproLastTrade struct {
@@ -20,9 +22,14 @@ type coinlistproLastTrade struct {
 }
 
 func (r *coinlistproResponse) Quote() (Quote, error) {
-	v, err := strconv.ParseFloat(r.LastTrade.Price, 64)
+	price, err := strconv.ParseFloat(r.LastTrade.Price, 64)
 	if err != nil {
-		return Quote{}, err
+		return Quote{}, fmt.Errorf("coinlistpro: error parsing price: %w", err)
+	}
+
+	vol, err := strconv.ParseFloat(r.VolumeBase24h, 64)
+	if err != nil {
+		return Quote{}, fmt.Errorf("coinlistpro: error parsing volume: %w", err)
 	}
 
 	quote := Quote{
@@ -30,7 +37,8 @@ func (r *coinlistproResponse) Quote() (Quote, error) {
 		//Timestamp: r.LastTrade.LogicalTime,
 		// not much trading going on. Prefer this to having blanks.
 		Timestamp: time.Now(),
-		Amount:    v,
+		Amount:    price,
+		VolumeBase24h: vol,
 	}
 	return quote, nil
 }
@@ -46,7 +54,7 @@ func (ex *Coinlistpro) Price(ctx context.Context, pair Pair) (Quote, error) {
 
 	return request(
 		ctx,
-		ex.url+"/v1/symbols/"+pair.String()+"/quote",
+		ex.url+"/v1/symbols/"+pair.String()+"/summary",
 		nil,
 		nil,
 		&coinlistproResponse{pair: pair},

--- a/quotetracker/coinlistpro.go
+++ b/quotetracker/coinlistpro.go
@@ -12,6 +12,7 @@ const coinlistproURL = "https://trade-api.coinlist.co"
 type coinlistproResponse struct {
 	pair Pair
 
+	Message       string               `json:"message"`
 	LastTrade     coinlistproLastTrade `json:"last_trade"`
 	VolumeBase24h string               `json:"volume_base_24h"`
 }
@@ -22,6 +23,10 @@ type coinlistproLastTrade struct {
 }
 
 func (r *coinlistproResponse) Quote() (Quote, error) {
+	if r.Message != "" {
+		return Quote{}, fmt.Errorf("coinlistpro: error: %s", r.Message)
+	}
+
 	price, err := strconv.ParseFloat(r.LastTrade.Price, 64)
 	if err != nil {
 		return Quote{}, fmt.Errorf("coinlistpro: error parsing price: %w", err)
@@ -36,8 +41,8 @@ func (r *coinlistproResponse) Quote() (Quote, error) {
 		Pair: r.pair,
 		//Timestamp: r.LastTrade.LogicalTime,
 		// not much trading going on. Prefer this to having blanks.
-		Timestamp: time.Now(),
-		Amount:    price,
+		Timestamp:     time.Now(),
+		Amount:        price,
 		VolumeBase24h: vol,
 	}
 	return quote, nil

--- a/quotetracker/coinlistpro_test.go
+++ b/quotetracker/coinlistpro_test.go
@@ -13,28 +13,28 @@ func coinlistproServer(t *testing.T) *httptest.Server {
 
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
-		if path != "/v1/symbols/FIL-USD/quote" {
+		if path != "/v1/symbols/FIL-USD/summary" {
 			t.Fatal("unexpected path ", path)
 		}
 
 		fmt.Fprintf(w, `
 {
+  "type": "spot",
+  "last_price": "76.35000000",
+  "lowest_ask": "76.55000000",
+  "highest_bid": "76.14000000",
   "last_trade": {
-    "price": "22.30000000",
-    "volume": "9.7465",
-    "imbalance": "190.2535",
-    "logical_time": "2021-01-20T12:39:33.000Z",
-    "auction_code": "FIL-USD-2021-01-20T12:39:33.000Z"
+    "price": "75.41000000",
+    "volume": "481.0000",
+    "imbalance": "61.6312",
+    "logicalTime": "2021-03-17T15:36:13.000Z",
+    "auctionCode": "FIL-USD-2021-03-17T15:36:13.000Z"
   },
-  "quote": {
-    "ask": "22.30000000",
-    "ask_size": "312.1919",
-    "bid": "22.25000000",
-    "bid_size": "312.0856"
-  },
-  "after_auction_code": "FIL-USD-2021-01-20T12:43:09.000Z",
-  "call_time": "2021-01-20T12:43:09.086Z",
-  "logical_time": "2021-01-20T12:43:09.000Z"
+  "volume_base_24h": "66321.3156",
+  "volume_quote_24h": "4271801.9941",
+  "price_change_percent_24h": "34.30079156",
+  "highest_price_24h": "76.28000000",
+  "lowest_price_24h": "56.85000000"
 }`)
 	}))
 
@@ -55,7 +55,10 @@ func TestCoinlistproPrice(t *testing.T) {
 	if q.Pair.Sell != FIL || q.Pair.Buy != USD {
 		t.Error("bad pair set")
 	}
-	if q.Amount != 22.30 {
+	if q.Amount != 75.41 {
 		t.Error("price amount not parsed correctly")
+	}
+	if q.VolumeBase24h != 66321.3156 {
+		t.Error("volume amount not parsed correctly")
 	}
 }

--- a/quotetracker/coinmarketcap.go
+++ b/quotetracker/coinmarketcap.go
@@ -28,7 +28,7 @@ type coinMarketCapData struct {
 
 type coinMarketCapQuote struct {
 	Price     float64 `json:"price"`
-	Volume24h float64 `json:"volume_24h"`
+	VolumeBase24h float64 `json:"volume_24h"`
 }
 
 func (r *coinMarketCapResponse) Quote() (Quote, error) {
@@ -50,6 +50,7 @@ func (r *coinMarketCapResponse) Quote() (Quote, error) {
 		Pair:      r.pair,
 		Timestamp: r.Status.Timestamp,
 		Amount:    r.Data[sell].Quote[buy].Price,
+		VolumeBase24h: r.Data[sell].Quote[buy].VolumeBase24h,
 	}
 	return quote, nil
 }

--- a/quotetracker/coinmarketcap_test.go
+++ b/quotetracker/coinmarketcap_test.go
@@ -94,4 +94,8 @@ func TestCoinMarketCapPrice(t *testing.T) {
 	if q.Amount != 21.58619654190641 {
 		t.Error("price amount not parsed correctly")
 	}
+
+	if q.VolumeBase24h != 251752867.90136266 {
+		t.Error("volume amount not parsed correctly")
+	}
 }

--- a/quotetracker/exchange.go
+++ b/quotetracker/exchange.go
@@ -19,6 +19,8 @@ const (
 	USD
 	FIL
 	USDT
+	BTC
+	ETH
 )
 
 // Symbol returns the symbol for a currency.
@@ -32,6 +34,10 @@ func (cur Currency) Symbol() string {
 		return "FIL"
 	case USDT:
 		return "USDT"
+	case BTC:
+		return "BTC"
+	case ETH:
+		return "ETH"
 	default:
 		return "UNKNOWN"
 	}

--- a/quotetracker/exchange.go
+++ b/quotetracker/exchange.go
@@ -58,15 +58,17 @@ func (p Pair) String() string {
 	return p.Sell.Symbol() + "-" + p.Buy.Symbol()
 }
 
-// Quote provides price information for a given pair.
+// Quote provides price information for a given pair and traded
+// volumes.
 type Quote struct {
-	Pair      Pair
-	Timestamp time.Time
-	Amount    float64
+	Pair          Pair
+	Timestamp     time.Time
+	Amount        float64
+	VolumeBase24h float64
 }
 
 func (q Quote) String() string {
-	return fmt.Sprintf("%s: %f (%s)", q.Pair, q.Amount, q.Timestamp)
+	return fmt.Sprintf("%s: %f | %f (%s)", q.Pair, q.Amount, q.VolumeBase24h, q.Timestamp)
 }
 
 // Exchange can be implemented by any service that can return current pricing quotes for a given pair.

--- a/quotetracker/gemini_test.go
+++ b/quotetracker/gemini_test.go
@@ -51,4 +51,8 @@ func TestGeminiPrice(t *testing.T) {
 	if q.Amount != 22.0384 {
 		t.Error("price amount not parsed correctly")
 	}
+
+	if q.VolumeBase24h != 8340.55228255 {
+		t.Error("volume amount not parsed correctly")
+	}
 }

--- a/quotetracker/huobi.go
+++ b/quotetracker/huobi.go
@@ -31,6 +31,7 @@ func (r *huobiResponse) Quote() (Quote, error) {
 		Pair:      r.pair,
 		Timestamp: time.Now(),
 		Amount:    r.Tick.Close,
+		VolumeBase24h: r.Tick.Vol,
 	}
 	return quote, nil
 }

--- a/quotetracker/huobi_test.go
+++ b/quotetracker/huobi_test.go
@@ -68,4 +68,8 @@ func TestHuobiPrice(t *testing.T) {
 	if q.Amount != 21.9954 {
 		t.Error("price amount not parsed correctly", q.Amount)
 	}
+
+	if q.VolumeBase24h != 22051370.789555945 {
+		t.Error("volume amount not parsed correctly", q.VolumeBase24h)
+	}
 }

--- a/quotetracker/kraken.go
+++ b/quotetracker/kraken.go
@@ -76,8 +76,17 @@ func (ex *Kraken) Price(ctx context.Context, pair Pair) (Quote, error) {
 		ex.url = krakenURL
 	}
 
+	sell := pair.Sell.Symbol()
+	buy := pair.Buy.Symbol()
+	if sell == "BTC" {
+		sell = "XBT"
+	}
+	if buy == "BTC" {
+		buy = "XBT"
+	}
+
 	q := url.Values{}
-	q.Add("pair", pair.Sell.Symbol()+pair.Buy.Symbol())
+	q.Add("pair", sell+buy)
 	return request(
 		ctx,
 		ex.url+"/0/public/Ticker",

--- a/quotetracker/kraken.go
+++ b/quotetracker/kraken.go
@@ -27,7 +27,14 @@ func (r *krakenResponse) Quote() (Quote, error) {
 		return Quote{}, fmt.Errorf("kraken: response has errors: %s", r.Error)
 	}
 
-	pairStr := r.pair.Sell.Symbol() + r.pair.Buy.Symbol()
+	// kraken returns pair strings like XXBTZUSD instead of BTCUSD
+	// Since we request a single one, let's just assume what we requested
+	// comes back.
+	var pairStr string
+	for k := range r.Result {
+		pairStr = k
+		break
+	}
 
 	if r.Result == nil ||
 		r.Result[pairStr] == nil ||
@@ -47,9 +54,9 @@ func (r *krakenResponse) Quote() (Quote, error) {
 	}
 
 	quote := Quote{
-		Pair:      r.pair,
-		Timestamp: time.Now(),
-		Amount:    price,
+		Pair:          r.pair,
+		Timestamp:     time.Now(),
+		Amount:        price,
 		VolumeBase24h: vol,
 	}
 

--- a/quotetracker/kraken_test.go
+++ b/quotetracker/kraken_test.go
@@ -83,4 +83,7 @@ func TestKrakenPrice(t *testing.T) {
 	if q.Amount != 21.58400 {
 		t.Error("price amount not parsed correctly")
 	}
+	if q.VolumeBase24h != 48009.68384317 {
+		t.Error("volume amount nor parsed correctly")
+	}
 }


### PR DESCRIPTION
This starts tracking 24h volumes for tracked trading pairs (in base currency), in micro units (like price). Also makes sure BTC and ETH pairs can be tracked too.