### PR TITLE
chore: Hide database url parse error

### DIFF
--- a/database.go
+++ b/database.go
@@ -2,14 +2,22 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/url"
 
 	"github.com/go-pg/pg/v10"
 	"github.com/go-pg/pg/v10/orm"
 )
 
-func setupDB(ctx context.Context, url string, poolSize int, appName string) (*pg.DB, error) {
-	opt, err := pg.ParseURL(url)
+func setupDB(ctx context.Context, dbURL string, poolSize int, appName string) (*pg.DB, error) {
+	// pre-emptively check for url parse failures so
+	// we don't print the failing url string to stdout
+	_, err := url.Parse(dbURL)
+	if err != nil {
+		return nil, errors.New("failed to parse url")
+	}
+	opt, err := pg.ParseURL(dbURL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Prevent printing the url secret to stdout when parsing fails. This is being changed because we automatically capture stdout in our logging pipeline and is a vector for accidentally leaking secrets.

This change checks parsing separately and then allows pg to check the other aspects of URL for connection purposes.