### PR TITLE
fix: Remove unneeded condition in docker CI workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3


### PR DESCRIPTION
- accidentally prevent running `build` on tags (and `publish` is skipped because it depends on `build`)